### PR TITLE
fix: atomic session patch write to avoid race conditions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -350,7 +350,14 @@ export function patchSessionModel(sessionsFile: string, sessionKey: string, mode
     if (!data[sessionKey]) return false;
     const prev = data[sessionKey].model;
     data[sessionKey].model = model;
-    fs.writeFileSync(sessionsFile, JSON.stringify(data, null, 0));
+    // atomic write: write to tmp file then rename
+    const tmpFile = `${sessionsFile}.tmp.${Date.now()}`;
+    try {
+      fs.writeFileSync(tmpFile, JSON.stringify(data, null, 0), { encoding: "utf-8", mode: 0o600 });
+      fs.renameSync(tmpFile, sessionsFile);
+    } finally {
+      try { if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile); } catch (e) { /* ignore */ }
+    }
     logger?.warn?.(`[self-heal] patched session model: ${sessionKey} ${prev} -> ${model}`);
     return true;
   } catch (e: any) {


### PR DESCRIPTION
This patch changes patchSessionModel to perform an atomic write (write to a temporary file and rename) to avoid race conditions when multiple plugins update sessions.json concurrently.\n\nChanges:\n- index.ts: patchSessionModel now writes to a tmp file and renames it (mode 600).\n\nNotes:\n- I did not run the full test suite here; please run CI.\n- Recommend merging after CI passes and bumping plugin version.